### PR TITLE
Fix FSM state clearing delay

### DIFF
--- a/app/handlers/client_requests.py
+++ b/app/handlers/client_requests.py
@@ -236,6 +236,10 @@ async def process_location(message: Message, state: FSMContext):
         parse_mode="HTML",
     )
 
+    # Завершаем FSM сразу после создания заявки, иначе пользователь
+    # не сможет начать новый диалог в течение минуты ожидания.
+    await state.clear()
+
     await asyncio.sleep(60)
 
     other_masters = [


### PR DESCRIPTION
## Summary
- clear FSM state right after request is created

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_683f3c14d22483229d045f291fbee20a